### PR TITLE
adds stock_unit_id to the product's variant transformer

### DIFF
--- a/lib/vtex/product_transformer.rb
+++ b/lib/vtex/product_transformer.rb
@@ -67,6 +67,7 @@ module VTEX
 
           {
             sku: variant_ref_id,
+            vtex_id: stock_unit_id,
             price: stock_unit.delete(:price),
             list_price: stock_unit.delete(:list_price),
             cost_price: stock_unit.delete(:cost_price),


### PR DESCRIPTION
Hello, we just realized that the vtex's stock_unit_id is required on our side as well. Would it be just this change to solve it?