### PR TITLE
fixes the vtex_id mixup

### DIFF
--- a/lib/vtex/product_transformer.rb
+++ b/lib/vtex/product_transformer.rb
@@ -56,6 +56,7 @@ module VTEX
         if unit = stock_units.find { |u| u[:ref_id] == ref_id }
           {
             sku: unit[:ref_id],
+            vtex_sku_id: unit[:id],
             price: unit[:price],
             list_price: unit[:list_price],
             cost_price: unit[:cost_price],
@@ -75,7 +76,8 @@ module VTEX
 
           {
             sku: variant_ref_id,
-            vtex_id: stock_unit_id,
+            vtex_id: stock_unit.delete(:product_id),
+            vtex_sku_id: stock_unit_id,
             price: stock_unit.delete(:price),
             list_price: stock_unit.delete(:list_price),
             cost_price: stock_unit.delete(:cost_price),

--- a/spec/vtex/clien_soap_spec.rb
+++ b/spec/vtex/clien_soap_spec.rb
@@ -10,6 +10,7 @@ module VTEX
 
         expect(response['id']).not_to be_present
         expect(response[:id]).to be_present
+        expect(response[:product_id]).not_to be_present
       end
     end
 
@@ -32,6 +33,7 @@ module VTEX
 
         expect(response['id']).not_to be_present
         expect(response[:id]).to be_present
+        expect(response[:product_id]).to be_present
       end
     end
   end


### PR DESCRIPTION
We are having an issue, where for unique products (products without variants) the "ID" that is saved as vtex_id, is the "product Id" (vtex name for it) even though it comes from the ID in the XML resultant from the product_get_all_from_updated_date_and_id soap call.

I tried saving the id that comes from product_get_by_ref_id as vtex_sku_id and the product_id as the current vtex_id - so we can still use this on the internal calls when needed.

If you could please check/test this and let me know if this makes sense. And if it brings the correct information.

Thank you.