### PR TITLE
returns categories split into nested arrays

### DIFF
--- a/lib/vtex/product_transformer.rb
+++ b/lib/vtex/product_transformer.rb
@@ -34,7 +34,7 @@ module VTEX
         json[:permalink] = json.delete('linkText')
         json[:categories] = json.delete('categories').reverse.map do |c|
           c.gsub!(/\A\/|\/\Z/,"")
-          c.split("/").last
+          c.split("/")
         end
         json[:variants] = []
         json.delete('items').to_a.each do |variant|


### PR DESCRIPTION
when categories returns more than 1 significative category

i.e.
```
"categories": [
"/Cachorro/Acessórios para Alimentação/Comedouros e Bebedouros/",
"/Cachorro/Acessórios para Alimentação/",
"/Cachorro/",
"/Gatos/Acessórios para Alimentação/",
"/Gatos/"
]
```
Right now it ends up creating a single array of the last occurences for each item.
```
['Gatos', 'Acessórios para Alimentação', 'Cachorro', 'Acessórios para Alimentação', 'Comedouros e Bebedouros']
```
And it should return N categories, split in nested arrays.

```
 [
  ['Cachorro', 'Acessórios para Alimentação', 'Comedouros e Bebedouros'],
  ['Cachorro', 'Acessórios para Alimentação'],
  ['Cachorro'],
  ['Gatos', 'Acessórios para Alimentação'],
  ['Gatos]
]
```